### PR TITLE
Add tests for external wincmds

### DIFF
--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -91,7 +91,7 @@ void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_move_cursor(Integer direction, Integer count)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
-void win_exchange(Integer win, Integer grid)
+void win_exchange(Integer win, Integer grid, Integer count)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_resize_equal (void)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1202,7 +1202,7 @@ static void win_exchange(long Prenum)
   }
 
   if (ui_is_external(kUIWindows)) {
-    ui_call_win_exchange(curwin->handle, curwin->w_grid.handle);
+    ui_call_win_exchange(curwin->handle, curwin->w_grid.handle, Prenum);
     return;
   }
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -82,6 +82,10 @@ end
 
 local session, loop_running, last_error
 
+local function get_session()
+  return session
+end
+
 local function set_session(s, keep)
   if session and not keep then
     session:close()
@@ -162,7 +166,7 @@ local function expect_msg_seq(...)
   error(final_error)
 end
 
-local function call_and_stop_on_error(...)
+local function call_and_stop_on_error(session, ...)
   local status, result = copcall(...)  -- luacheck: ignore
   if not status then
     session:stop()
@@ -172,24 +176,24 @@ local function call_and_stop_on_error(...)
   return result
 end
 
-local function run(request_cb, notification_cb, setup_cb, timeout)
+local function run_session(session, request_cb, notification_cb, setup_cb, timeout)
   local on_request, on_notification, on_setup
 
   if request_cb then
     function on_request(method, args)
-      return call_and_stop_on_error(request_cb, method, args)
+      return call_and_stop_on_error(session, request_cb, method, args)
     end
   end
 
   if notification_cb then
     function on_notification(method, args)
-      call_and_stop_on_error(notification_cb, method, args)
+      call_and_stop_on_error(session, notification_cb, method, args)
     end
   end
 
   if setup_cb then
     function on_setup()
-      call_and_stop_on_error(setup_cb)
+      call_and_stop_on_error(session, setup_cb)
     end
   end
 
@@ -201,6 +205,10 @@ local function run(request_cb, notification_cb, setup_cb, timeout)
     last_error = nil
     error(err)
   end
+end
+
+local function run(request_cb, notification_cb, setup_cb, timeout)
+  run_session(session, request_cb, notification_cb, setup_cb, timeout)
 end
 
 local function stop()
@@ -666,6 +674,7 @@ local module = {
   buffer = buffer,
   bufmeths = bufmeths,
   call = nvim_call,
+  create_callindex = create_callindex,
   clear = clear,
   command = nvim_command,
   connect = connect,
@@ -690,6 +699,7 @@ local module = {
   filter = filter,
   funcs = funcs,
   get_pathsep = get_pathsep,
+  get_session = get_session,
   insert = insert,
   iswin = iswin,
   map = map,
@@ -720,6 +730,7 @@ local module = {
   retry = retry,
   rmdir = rmdir,
   run = run,
+  run_session = run_session,
   set_session = set_session,
   set_shell_powershell = set_shell_powershell,
   skip_fragile = skip_fragile,

--- a/test/functional/ui/ext_win_spec.lua
+++ b/test/functional/ui/ext_win_spec.lua
@@ -1,0 +1,60 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
+
+describe('In ext-win mode', function()
+  local screen
+  local nvim_argv = {helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+                     '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
+                     '--embed'}
+
+  before_each(function()
+    local screen_nvim = spawn(nvim_argv)
+    set_session(screen_nvim)
+    screen = Screen.new()
+    -- TODO(utkarshme): should not have to set ext_multigrid
+    screen:attach({ext_windows=true, ext_multigrid=true})
+    screen:set_default_attr_ids({
+      [1] = {bold = true, reverse = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue1}
+    })
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('default initial screen is correct', function()
+    screen:expect([[
+    ## grid 1
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+      {1:[No Name]                                            }|
+                                                           |
+    ## grid 2
+      ^                                                     |
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+      {2:~                                                    }|
+    ]])
+  end)
+
+end)

--- a/test/functional/ui/ext_win_spec.lua
+++ b/test/functional/ui/ext_win_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
+local feed, command = helpers.feed, helpers.command
+local eq, iswin = helpers.eq, helpers.iswin
 
 describe('In ext-win mode', function()
   local screen
@@ -11,13 +13,75 @@ describe('In ext-win mode', function()
   before_each(function()
     local screen_nvim = spawn(nvim_argv)
     set_session(screen_nvim)
-    screen = Screen.new()
+    screen = Screen.new(15, 5)
     -- TODO(utkarshme): should not have to set ext_multigrid
     screen:attach({ext_windows=true, ext_multigrid=true})
     screen:set_default_attr_ids({
       [1] = {bold = true, reverse = true},
-      [2] = {bold = true, foreground = Screen.colors.Blue1}
+      [2] = {bold = true, foreground = Screen.colors.Blue1},
+      [3] = {reverse = true},
+      [4] = {bold = true},
+      [5] = {background = Screen.colors.LightGrey, underline = true},
+      [6] = {bold = true, foreground = Screen.colors.Magenta}
     })
+    screen:set_on_event_handler(function(name, data)
+      if name == 'win_split' then
+        local win1, grid1, win2, grid2, flags = unpack(data)
+        screen.split = {
+          old_win = {win1, grid1},
+          new_win = {win2, grid2},
+          flags = flags
+        }
+      elseif name == 'win_rotate' then
+        local win, grid, direction, count = unpack(data)
+        screen.rotate = {
+          win = win,
+          grid = grid,
+          direction = direction,
+          count = count
+        }
+      elseif name == 'win_exchange' then
+        local win, grid, count = unpack(data)
+        screen.exchange = {
+          win = win,
+          grid = grid,
+          count = count
+        }
+      elseif name == 'win_move' then
+        local win, grid, flags = unpack(data)
+        screen.win_move = {
+          win = win,
+          grid = grid,
+          flags = flags
+        }
+      elseif name == 'win_resize_equal' then
+        screen.got_resize_equal = true
+      elseif name == 'win_height_set' then
+        local win, grid, height = unpack(data)
+        screen.height_set = {
+          win = win, grid = grid, height = height
+        }
+      elseif name == 'win_width_set' then
+        local win, grid, width = unpack(data)
+        screen.width_set = {
+          win = win, grid = grid, width = width
+        }
+      elseif name == 'win_close' then
+        local win, grid = unpack(data)
+        screen.win_close = {
+          win = win, grid = grid
+        }
+      end
+    end)
+    screen:set_on_request_handler(function(method, args)
+      if method == 'win_move_cursor' then
+        local direction, count = unpack(args)
+        screen.move_cursor = {
+          direction = direction,
+          count = count
+        }
+      end
+    end)
   end)
 
   after_each(function()
@@ -27,34 +91,322 @@ describe('In ext-win mode', function()
   it('default initial screen is correct', function()
     screen:expect([[
     ## grid 1
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-                                                           |
-      {1:[No Name]                                            }|
-                                                           |
+                     |
+                     |
+                     |
+      {1:[No Name]      }|
+                     |
     ## grid 2
-      ^                                                     |
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
-      {2:~                                                    }|
+      ^               |
+      {2:~              }|
+      {2:~              }|
     ]])
   end)
 
+  describe(':(v)split', function()
+    it('creates empty grids', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(0, screen.split.flags)
+        eq(2, screen.split.old_win[2])
+        eq(3, screen.split.new_win[2])
+        -- TODO
+        --screen:try_resize_grid(screen.split.old_win[2], 30, 30)
+        --screen:try_resize_grid(screen.split.new_win[2], 30, 30)
+        --screen:snapshot_util()
+      end)
+
+      command('vsplit')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ## grid 4
+      ]], nil, nil, function()
+        eq(2, screen.split.flags)
+        iswin(screen.split.old_win[1])
+        eq(3, screen.split.old_win[2])
+        iswin(screen.split.new_win[1])
+        eq(4, screen.split.new_win[2])
+        -- TODO
+        --screen:try_resize_grid(screen.split.old_win[2], 10, 10)
+        --screen:try_resize_grid(screen.split.new_win[2], 10, 10)
+        --screen:snapshot_util()
+      end)
+    end)
+  end)
+
+  describe(':resize', function()
+    it('sends height_set event', function()
+      command('resize 5')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.height_set.win)
+        eq(2, screen.height_set.grid)
+        eq(5, screen.height_set.height)
+      end)
+    end)
+  end)
+
+  describe(':vertical resize', function()
+    it('sends width_set event', function()
+      command('vertical resize 5')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.width_set.win)
+        eq(2, screen.width_set.grid)
+        eq(5, screen.width_set.width)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-r', function()
+    it('sends rotate event', function()
+      command('split')
+      feed('<C-W>r')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.rotate.win)
+        eq(3, screen.rotate.grid)
+        eq(1, screen.rotate.count)
+        eq(0, screen.rotate.direction)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-x', function()
+    it('sends exchange event', function()
+      command('split')
+      feed('<C-W>x')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.exchange.win)
+        eq(3, screen.exchange.grid)
+        eq(0, screen.exchange.count)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-J', function()
+    it('sends win_move event', function()
+      command('split')
+      feed('<C-W>J')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.win_move.win)
+        eq(3, screen.win_move.grid)
+        eq(1, screen.win_move.flags)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W T', function()
+    it('sends win_close and creates a new grid', function()
+      command('split')
+      feed('<C-W>T')
+      screen:expect([[
+      ## grid 1
+        {4: Name]  Name] }{5:X}|
+                       |
+                       |
+                       |
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.win_close.win)
+        eq(3, screen.win_close.grid)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W =', function()
+    it('sends resize_equal event', function()
+      command('split')
+      feed('<C-W>=')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(true, screen.got_resize_equal)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-+', function()
+    it('sends win_height_set event', function()
+      feed('<C-W>+')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.height_set.win)
+        eq(2, screen.height_set.grid)
+        eq(4, screen.height_set.height)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-j', function()
+    it('sends move_cursor event', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]])
+      feed('<C-W>j')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(0, screen.move_cursor.direction)
+        eq(1, screen.move_cursor.count)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-c', function()
+    it('sends close event', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]])
+      feed('<C-W>c')
+      screen:expect([[
+      ## grid 1
+                       |
+                       |
+                       |
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.win_close.win)
+        eq(3, screen.win_close.grid)
+      end)
+    end)
+  end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1,0 +1,1296 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local os = require('os')
+local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
+local command, feed_command = helpers.command, helpers.feed
+local eval, exc_exec = helpers.eval, helpers.exc_exec
+local feed_command, eq = helpers.feed_command, helpers.eq
+local meths = helpers.meths
+local curbufmeths = helpers.curbufmeths
+local funcs = helpers.funcs
+local run = helpers.run
+
+describe('floating windows', function()
+  before_each(function()
+    clear()
+  end)
+  local attrs = {
+    [0] = {bold=true, foreground=Screen.colors.Blue},
+    [1] = {background = Screen.colors.LightMagenta},
+    [2] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
+    [3] = {bold = true},
+    [4] = {bold = true, reverse = true},
+    [5] = {reverse = true},
+    [6] = {background = Screen.colors.LightMagenta, bold = true, reverse = true},
+    [7] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+    [8] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    [9] = {background = Screen.colors.LightGrey, underline = true},
+    [10] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta},
+    [11] = {bold = true, foreground = Screen.colors.Magenta},
+  }
+
+  function with_multigrid(multigrid)
+    before_each(function()
+      screen = Screen.new(40,7)
+      screen:attach({ext_float=multigrid})
+      screen:set_default_attr_ids(attrs)
+    end)
+
+    it('can be created and reconfigured', function()
+      buf = meths.create_buf(false)
+      win = meths.open_float_win(buf, false, 20, 2, {x=5, y=2})
+      meths.win_set_option(win , 'winhl', 'Normal:PMenu')
+      local expected_info = {[2]={
+        {id=1001}, 20, 2, {
+          anchor='NW',
+          relative='editor',
+          standalone=false,
+          x=5,y=2,
+        }
+      }}
+
+
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+        ## grid 2
+          {1:                    }|
+          {2:~                   }|
+        ]], nil, nil, function()
+          eq(expected_info, screen.float_info)
+        end)
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{1:                    }{0:               }|
+          {0:~    }{2:~                   }{0:               }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+          ]])
+      end
+
+
+      meths.win_config_float(win,0,0,{x=10, y=0})
+      expected_info[2][4].x = 10
+      expected_info[2][4].y = 0
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+        ## grid 2
+          {1:                    }|
+          {2:~                   }|
+        ]], nil, nil, function()
+          eq(expected_info, screen.float_info)
+        end)
+      else
+        screen:expect([[
+          ^          {1:                    }          |
+          {0:~         }{2:~                   }{0:          }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+        ]])
+      end
+    end)
+
+    if multigrid then
+      pending("supports second UI without multigrid", function()
+        local session2 = helpers.connect(eval('v:servername'))
+        print(session2:request("nvim_eval", "2+2"))
+        local screen2 = Screen.new(40,7)
+        screen2:attach(nil, session2)
+        screen2:set_default_attr_ids(attrs)
+        -- TODO: delet this:
+        screen2:set_on_event_handler(function(name, data)
+        end)
+        buf = meths.create_buf(false)
+        win = meths.open_float_win(buf, true, 20, 2, {x=5, y=2})
+        meths.win_set_option(win, 'winhl', 'Normal:PMenu')
+        local expected_info = {[2]={
+          {id=1001}, 20, 2, {
+            anchor='NW',
+            relative='editor',
+            standalone=false,
+            x=5,y=2,
+          }
+        }}
+        print("x")
+        screen:expect([[
+        ## grid 1
+                                                  |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+        ## grid 2
+          {1:^                    }|
+          {2:~                   }|
+        ]], nil, nil, function()
+          eq(expected_info, screen.float_info)
+        end)
+        screen2:expect([[
+                                                  |
+          {0:~                                       }|
+          {0:~    }{1:^                    }{0:               }|
+          {0:~    }{2:~                   }{0:               }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+          ]])
+      end)
+    end
+
+
+    describe("handles :wincmd", function()
+      local win
+      local expected_info
+      before_each(function()
+        -- the default, but be explicit:
+        command("set laststatus=1")
+        command("set hidden")
+        meths.buf_set_lines(0,0,-1,true,{"x"})
+        buf = meths.create_buf(false)
+        win = meths.open_float_win(buf, false, 20, 2, {x=5, y=2})
+        meths.buf_set_lines(buf,0,-1,true,{"y"})
+        meths.win_set_option(win , 'winhl', 'Normal:PMenu')
+        expected_info = {[2]={
+          {id=1001}, 20, 2, {
+            anchor='NW',
+            relative='editor',
+            standalone=false,
+            x=5,y=2,
+          }
+        }}
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+        ]], nil, nil, function()
+          eq(expected_info, screen.float_info)
+        end)
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("w", function()
+        feed("<c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {0:~    }{1:^y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("W", function()
+        feed("<c-w>W")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {0:~    }{1:^y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>W")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("j", function()
+        feed("<c-w>ji") -- INSERT to trigger screen change
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {3:-- INSERT --}                            |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {3:-- INSERT --}                            |
+          ]])
+        end
+
+        feed("<esc><c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {0:~    }{1:^y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>j")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+      end)
+
+      it("s :split (non-float)", function()
+        feed("<c-w>s")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {5:[No N}{1:y                   }{5:               }|
+            ^x    {2:~                   }               |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {5:[No N}{1:^y                   }{5:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+
+        feed("<c-w>w")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("s :split (float)", function()
+        feed("<c-w>w<c-w>s")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            {1:^y                                       }|
+            {2:~                                       }|
+            {6:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            {1:^y                                       }|
+            {2:~                                       }|
+            {6:[No N}{1:y                   }{6:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed(":set winhighlight=<cr><c-l>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^y                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^y                                       |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+
+        feed("<c-w>j")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            y                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            y                                       |
+            {0:~                                       }|
+            {5:[No N}{1:y                   }{5:               }|
+            ^x    {2:~                   }               |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>ji")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            y                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            {3:-- INSERT --}                            |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            y                                       |
+            {0:~                                       }|
+            {5:[No N}{1:y                   }{5:               }|
+            ^x    {2:~                   }               |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            {3:-- INSERT --}                            |
+          ]])
+        end
+      end)
+
+      it(":new (non-float)", function()
+        feed(":new<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^                                        |
+            {0:~                                       }|
+            {4:[No Name]                               }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            :new                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^                                        |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            :new                                    |
+          ]])
+        end
+      end)
+
+      it(":new (float)", function()
+        feed("<c-w>w:new<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^                                        |
+            {0:~                                       }|
+            {4:[No Name]                               }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            :new                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^                                        |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            :new                                    |
+          ]])
+        end
+      end)
+
+      it("v :vsplit (non-float)", function()
+        feed("<c-w>v")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                   {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name] [+]        }{5:[No Name] [+]      }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                   {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name] [+]        }{5:[No Name] [+]      }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it(":vnew (non-float)", function()
+        feed(":vnew<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^                    {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name]            }{5:[No Name] [+]      }|
+            :vnew                                   |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+        screen:expect([[
+          ^                    {5:│}x                  |
+          {0:~                   }{5:│}{0:~                  }|
+          {0:~    }{1:y                   }{0:               }|
+          {0:~    }{2:~                   }{0:               }|
+          {0:~                   }{5:│}{0:~                  }|
+          {4:[No Name]            }{5:[No Name] [+]      }|
+          :vnew                                   |
+        ]])
+        end
+      end)
+
+      it(":vnew (float)", function()
+        feed("<c-w>w:vnew<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^                    {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name]            }{5:[No Name] [+]      }|
+            :vnew                                   |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^                    {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name]            }{5:[No Name] [+]      }|
+            :vnew                                   |
+          ]])
+        end
+      end)
+
+      it("exit by disconnect", function()
+        -- FIXME: clear() is not enough, lua error must be triggered
+        -- to detect ASAN failure. Maybe ignore this for now,
+        -- as travis ASAN will detect this anyway...
+        assert(false)
+      end)
+
+
+      it("q (:quit) last non-float exits nvim", function()
+        command('autocmd VimLeave    * call rpcnotify(1, "exit")')
+        -- avoid unsaved change in other buffer
+        feed("<c-w><c-w>:w Xtest_written2<cr><c-w><c-w>")
+        -- quit in last non-float
+        feed(":wq Xtest_written<cr>")
+        local function on_request(name, args)
+          eq("exit", name)
+          exited = true
+        end
+        run(on_request, nil, nil)
+        os.remove('Xtest_written')
+        os.remove('Xtest_written2')
+      end)
+
+      it("o (:only) non-float", function()
+        feed("<c-w>o")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("o (:only) float fails", function()
+        feed("<c-w>w<c-w>o")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            EXXX: floating win...not be only window |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {0:~    }{1:^y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+            EXXX: floating win...not be only window |
+          ]])
+        end
+      end)
+
+      it("o (:only) non-float with split", function()
+        feed("<c-w>s")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {4:[No N}{1:y                   }{4:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>o")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        else
+          screen:expect([[
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it("o (:only) float with split", function()
+        feed("<c-w>s<c-w>W")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {5:[No N}{1:^y                   }{5:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed("<c-w>o")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            EXXX: floating win...not be only window |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {5:[No N}{1:^y                   }{5:               }|
+            x    {2:~                   }               |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            EXXX: floating win...not be only window |
+          ]])
+        end
+      end)
+
+      it("J (float)", function()
+        feed("<c-w>w<c-w>J")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {7:EXXX: cannot attach this float}          |
+          ## grid 2
+            {1:^y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {0:~    }{1:^y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {7:EXXX: cannot attach this float}          |
+          ]])
+        end
+
+        meths.win_config_float(0,0,0,{standalone=true})
+        feed(":<esc><c-w>J")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            {1:^y                                       }|
+            {2:~                                       }|
+            {6:[No Name] [+]                           }|
+                                                    |
+          ]])
+        else
+          screen:expect([[
+            x                                       |
+            {0:~                                       }|
+            {5:[No Name] [+]                           }|
+            {1:^y                                       }|
+            {2:~                                       }|
+            {6:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+      end)
+
+      it('movements with nested split layout', function()
+        command("set hidden")
+        feed("<c-w>s<c-w>v<c-w>b<c-w>v")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            x                   {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {5:[No Name] [+]        [No Name] [+]      }|
+            ^x                   {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name] [+]        }{5:[No Name] [+]      }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            x                   {5:│}x                  |
+            {0:~                   }{5:│}{0:~                  }|
+            {5:[No N}{1:y                   }{5:Name] [+]      }|
+            ^x    {2:~                   }               |
+            {0:~                   }{5:│}{0:~                  }|
+            {4:[No Name] [+]        }{5:[No Name] [+]      }|
+                                                    |
+          ]])
+        end
+
+        -- verify that N<c-w>w works
+        for i = 1,5 do
+          feed(i.."<c-w>w")
+          feed_command("enew")
+          curbufmeths.set_lines(0,-1,true,{tostring(i)})
+        end
+
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            1                  {5:│}2                   |
+            {0:~                  }{5:│}{0:~                   }|
+            {5:[No Name] [+]       [No Name] [+]       }|
+            3                  {5:│}4                   |
+            {0:~                  }{5:│}{0:~                   }|
+            {5:[No Name] [+]       [No Name] [+]       }|
+            :enew                                   |
+          ## grid 2
+            ^5                   |
+            {0:~                   }|
+          ]])
+        else
+          screen:expect([[
+            1                  {5:│}2                   |
+            {0:~                  }{5:│}{0:~                   }|
+            {5:[No N}^5                   {5:ame] [+]       }|
+            3    {0:~                   }               |
+            {0:~                  }{5:│}{0:~                   }|
+            {5:[No Name] [+]       [No Name] [+]       }|
+            :enew                                   |
+          ]])
+        end
+
+        movements = {
+          w={2,3,4,5,1},
+          W={5,1,2,3,4},
+          h={1,1,3,3,3},
+          j={3,3,3,4,4},
+          k={1,2,1,1,1},
+          l={2,2,4,4,4},
+          t={1,1,1,1,1},
+          b={4,4,4,4,4},
+          p={4,4,4,3,3} -- TODO: not really proper, add dedicated test?
+        }
+
+        for k,v in pairs(movements) do
+          for i = 1,5 do
+            feed(i.."<c-w>w")
+            feed('<c-w>'..k)
+            local nr = funcs.winnr()
+            eq(v[i],nr, "when using <c-w>"..k.." from window "..i)
+          end
+        end
+      end)
+
+      it(":tabnew and :tabnext", function()
+        feed(":tabnew<cr>")
+        if multigrid then
+          -- grid is not freed, but float is marked as closed (should it rather be "invisible"?)
+          screen:expect([[
+          ## grid 1
+            {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]], nil, nil, function()
+            eq({}, screen.float_info)
+          end)
+        else
+          screen:expect([[
+            {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+        feed(":tabnext<cr>")
+        if multigrid then
+            -- TODO: doesn't work
+          screen:expect([[
+          ## grid 1
+            {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]], nil, nil, function()
+            eq(expected_info, screen.float_info)
+          end)
+        else
+          screen:expect([[
+            {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
+            ^x                                       |
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed(":tabnext<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]], nil, nil, function()
+            eq({}, screen.float_info)
+          end)
+        else
+          screen:expect([[
+            {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+      end)
+
+      it(":tabnew and :tabnext (standalone)", function()
+        meths.win_config_float(win,0,0,{standalone=true})
+        feed(":tabnew<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
+            ^                                        |
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {0:~                                       }|
+                                                    |
+          ]])
+        end
+
+        feed(":tabnext<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
+            ^x                                       |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
+            ^x                                       |
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {4:[No Name] [+]                           }|
+                                                    |
+          ]])
+        end
+
+        feed(":tabnext<cr>")
+        if multigrid then
+          screen:expect([[
+          ## grid 1
+            {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
+            ^                                        |
+            {0:~                                       }|
+            {0:~                                       }|
+            {0:~                                       }|
+            {4:[No Name]                               }|
+                                                    |
+          ## grid 2
+            {1:y                   }|
+            {2:~                   }|
+          ]])
+        else
+          screen:expect([[
+            {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
+            ^                                        |
+            {0:~    }{1:y                   }{0:               }|
+            {0:~    }{2:~                   }{0:               }|
+            {0:~                                       }|
+            {4:[No Name]                               }|
+                                                    |
+          ]])
+        end
+      end)
+
+      pending("templaty", function()
+        feed("<c-w>")
+        if multigrid then
+          screen:snapshot_util()
+        else
+          screen:snapshot_util()
+        end
+      end)
+    end)
+  end
+
+  describe('with multigrid', function()
+    with_multigrid(true)
+  end)
+  describe('without multigrid', function()
+    with_multigrid(false)
+  end)
+
+end)
+

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -177,15 +177,13 @@ function Screen:attach(options, session)
   if options == nil then
     options = {rgb=true}
   end
-  options.ext_newgrid = true
-  --options.ext_multigrid = true
   self._options = options
   if session == nil then
     session = get_session()
   end
-  if options.ext_float then
-    options.ext_multigrid = true
-    self._float = true
+  if options.ext_float or options.ext_multigrid then
+    options.ext_newgrid = true
+    self._multigrid = true
   end
 
   self._session = session
@@ -201,6 +199,12 @@ function Screen:try_resize(columns, rows)
   self.uimeths.try_resize(columns, rows)
   -- Give ourselves a chance to _handle_resize, which requires using
   -- self.sleep() (for the resize notification) rather than run()
+  self:sleep(0.1)
+end
+
+function Screen:try_resize_grid(grid, columns, rows)
+  self._grid = self._grids[1]
+  self.uimeths.try_resize_grid(grid, columns, rows)
   self:sleep(0.1)
 end
 
@@ -676,7 +680,7 @@ function Screen:find_attrs(attrs)
 end
 
 function Screen:render(headers,attrs,ignore,preview)
-  headers = headers and self._float
+  headers = headers and self._multigrid
   local rv = {}
   for igrid,grid in ipairs(self._grids) do
     if headers then

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -422,6 +422,10 @@ function Screen:_handle_grid_cursor_goto(grid, row, col)
   self._cursor.col = col + 1
 end
 
+function Screen:_handle_win_position(win, grid, row, col, width, height)
+  --TODO(utkarshme)
+end
+
 function Screen:_handle_float_info(win, grid, width, height, options)
   --assert(self._multigrid)
   self.float_info[grid] = {win, width, height, options}

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -138,15 +138,19 @@ function Screen.new(width, height)
     suspended = false,
     mode = 'normal',
     options = {},
+    float_info = {},
+    _session = nil,
     _default_attr_ids = nil,
     _default_attr_ignore = nil,
     _mouse_enabled = true,
     _attrs = {},
     _attr_table = {[0]={}},
+    _grids = {},
     _cursor = {
-      row = 1, col = 1
+      grid = 1, row = 1, col = 1
     },
-    _busy = false
+    _busy = false,
+    _multigrid = false
   }, Screen)
   self:_handle_resize(width, height)
   return self
@@ -165,8 +169,18 @@ function Screen:attach(options)
     options = {rgb=true}
   end
   options.ext_newgrid = true
+  --options.ext_multigrid = true
   self._options = options
-  uimeths.attach(self._width, self._height, options)
+  if session == nil then
+    session = get_session()
+  end
+  if options.ext_float then
+    options.ext_multigrid = true
+    self._float = true
+  end
+
+  self._session = session
+  self.uimeths.attach(self._grid.width, self._grid.height, options)
 end
 
 function Screen:detach()
@@ -210,13 +224,7 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
     -- value.
     expected = dedent(expected:gsub('\n[ ]+$', ''), 0)
     for row in expected:gmatch('[^\n]+') do
-      row = row:sub(1, #row - 1) -- Last char must be the screen delimiter.
       table.insert(expected_rows, row)
-    end
-    if not any then
-      assert(self._height == #expected_rows,
-        "Expected screen state's row count(" .. #expected_rows
-        .. ') differs from configured height(' .. self._height .. ') of Screen.')
     end
   end
   local ids = attr_ids or self._default_attr_ids
@@ -228,10 +236,7 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
         return tostring(res)
       end
     end
-    local actual_rows = {}
-    for i = 1, self._height do
-      actual_rows[i] = self:_row_repr(self._rows[i], ids, ignore)
-    end
+    local actual_rows = self:render(not any, ids, ignore)
 
     if expected == nil then
       return
@@ -245,8 +250,12 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
           .. 'Actual:\n  |' .. table.concat(actual_rows, '|\n  |') .. '|\n\n')
       end
     else
+      if #actual_rows ~= #expected_rows then
+        return "Expected screen state's row count(" .. #expected_rows
+        .. ') differs from configured height(' .. #actual_rows .. ') of Screen.'
+      end
       -- `expected` must match the screen lines exactly.
-      for i = 1, self._height do
+      for i = 1, #actual_rows do
         if expected_rows[i] ~= actual_rows[i] then
           local msg_expected_rows = {}
           for j = 1, #expected_rows do
@@ -256,8 +265,8 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
           actual_rows[i] = '*' .. actual_rows[i]
           return (
             'Row ' .. tostring(i) .. ' did not match.\n'
-            ..'Expected:\n  |'..table.concat(msg_expected_rows, '|\n  |')..'|\n'
-            ..'Actual:\n  |'..table.concat(actual_rows, '|\n  |')..'|\n\n'..[[
+            ..'Expected:\n  |'..table.concat(msg_expected_rows, '\n  |')..'|\n'
+            ..'Actual:\n  |'..table.concat(actual_rows, '\n  |')..'\n\n'..[[
 To print the expect() call that would assert the current screen state, use
 screen:snapshot_util(). In case of non-deterministic failures, use
 screen:redraw_debug() to show all intermediate screen states.  ]])
@@ -331,7 +340,7 @@ function Screen:_redraw(updates)
         self._on_event(method, update[i])
       end
     end
-    -- print(self:_current_screen())
+    -- self.print_snapshot()
   end
 end
 
@@ -340,6 +349,14 @@ function Screen:set_on_event_handler(callback)
 end
 
 function Screen:_handle_resize(width, height)
+  self:_handle_grid_resize(1, width, height)
+  self._scroll_region = {
+    top = 1, bot = height, left = 1, right = width
+  }
+  self._grid = self._grids[1]
+end
+
+function Screen:_handle_grid_resize(grid, width, height)
   local rows = {}
   for _ = 1, height do
     local cols = {}
@@ -350,16 +367,11 @@ function Screen:_handle_resize(width, height)
   end
   self._cursor.row = 1
   self._cursor.col = 1
-  self._rows = rows
-  self._width = width
-  self._height = height
-  self._scroll_region = {
-    top = 1, bot = height, left = 1, right = width
+  self._grids[grid] = {
+    rows=rows,
+    width=width,
+    height=height,
   }
-end
-
-function Screen:_handle_grid_resize(grid, width, height)
-    self:_handle_resize(width, height)
 end
 
 
@@ -369,16 +381,20 @@ function Screen:_handle_mode_info_set(cursor_style_enabled, mode_info)
 end
 
 function Screen:_handle_clear()
-  self:_clear_block(1, self._height, 1, self._width)
+  self:_handle_grid_clear(1)
 end
 
 function Screen:_handle_grid_clear(grid)
-    self:_handle_clear()
+  self:_clear_block(self._grids[grid], 1, self._grids[grid].height, 1, self._grids[grid].width)
+end
+
+function Screen:_handle_grid_destroy(grid)
+  self._grids[grid] = nil
 end
 
 function Screen:_handle_eol_clear()
   local row, col = self._cursor.row, self._cursor.col
-  self:_clear_block(row, row, col, self._scroll_region.right)
+  self:_clear_block(self._grid, row, row, col, self._grid.width)
 end
 
 function Screen:_handle_cursor_goto(row, col)
@@ -387,8 +403,19 @@ function Screen:_handle_cursor_goto(row, col)
 end
 
 function Screen:_handle_grid_cursor_goto(grid, row, col)
+  self._cursor.grid = grid
   self._cursor.row = row + 1
   self._cursor.col = col + 1
+end
+
+function Screen:_handle_float_info(win, grid, width, height, options)
+  --assert(self._multigrid)
+  self.float_info[grid] = {win, width, height, options}
+end
+
+function Screen:_handle_float_close(win, grid)
+  --assert(self._multigrid)
+  self.float_info[grid] = nil
 end
 
 function Screen:_handle_busy_start()
@@ -413,9 +440,9 @@ function Screen:_handle_mode_change(mode, idx)
 end
 
 function Screen:_handle_set_scroll_region(top, bot, left, right)
-  self._scroll_region.top = top + 1
+  self._scroll_region.top = top
   self._scroll_region.bot = bot + 1
-  self._scroll_region.left = left + 1
+  self._scroll_region.left = left
   self._scroll_region.right = right + 1
 end
 
@@ -424,22 +451,29 @@ function Screen:_handle_scroll(count)
   local bot = self._scroll_region.bot
   local left = self._scroll_region.left
   local right = self._scroll_region.right
+  self:_handle_grid_scroll(1, top, bot, left, right, count, 0)
+end
+
+function Screen:_handle_grid_scroll(grid, top, bot, left, right, rows, cols)
+  top = top+1
+  left = left+1
+  local grid = self._grids[grid]
   local start, stop, step
 
-  if count > 0 then
+  if rows > 0 then
     start = top
-    stop = bot - count
+    stop = bot - rows
     step = 1
   else
     start = bot
-    stop = top - count
+    stop = top - rows
     step = -1
   end
 
   -- shift scroll region
   for i = start, stop, step do
-    local target = self._rows[i]
-    local source = self._rows[i + count]
+    local target = grid.rows[i]
+    local source = grid.rows[i + rows]
     for j = left, right do
       target[j].text = source[j].text
       target[j].attrs = source[j].attrs
@@ -447,15 +481,9 @@ function Screen:_handle_scroll(count)
   end
 
   -- clear invalid rows
-  for i = stop + step, stop + count, step do
-    self:_clear_row_section(i, left, right)
+  for i = stop + step, stop + rows, step do
+    self:_clear_row_section(grid, i, left, right)
   end
-end
-
-function Screen:_handle_grid_scroll(grid, top, bot, left, right, rows, cols)
-    -- TODO: if we truly believe we should translate the other way
-    self:_handle_set_scroll_region(top,bot-1,left,right-1)
-    self:_handle_scroll(rows)
 end
 
 function Screen:_handle_hl_attr_define(id,attrs,inspect)
@@ -483,14 +511,14 @@ function Screen:_handle_highlight_set(attrs)
 end
 
 function Screen:_handle_put(str)
-  local cell = self._rows[self._cursor.row][self._cursor.col]
+  local cell = self._grid.rows[self._cursor.row][self._cursor.col]
   cell.text = str
   cell.attrs = self._attrs
   self._cursor.col = self._cursor.col + 1
 end
 
 function Screen:_handle_grid_line(grid, row, col, cells)
-  local line = self._rows[row+1]
+  local line = self._grids[grid].rows[row+1]
   local colpos = col+1
   local hl = {}
   for _,cell in ipairs(cells) do
@@ -550,24 +578,24 @@ function Screen:_handle_option_set(name, value)
   self.options[name] = value
 end
 
-function Screen:_clear_block(top, bot, left, right)
+function Screen:_clear_block(grid, top, bot, left, right)
   for i = top, bot do
-    self:_clear_row_section(i, left, right)
+    self:_clear_row_section(grid, i, left, right)
   end
 end
 
-function Screen:_clear_row_section(rownum, startcol, stopcol)
-  local row = self._rows[rownum]
+function Screen:_clear_row_section(grid, rownum, startcol, stopcol)
+  local row = grid.rows[rownum]
   for i = startcol, stopcol do
     row[i].text = ' '
     row[i].attrs = {}
   end
 end
 
-function Screen:_row_repr(row, attr_ids, attr_ignore)
+function Screen:_row_repr(row, attr_ids, attr_ignore, cursor)
   local rv = {}
   local current_attr_id
-  for i = 1, self._width do
+  for i = 1, #row do
     local attr_id = self:_get_attr_id(attr_ids, attr_ignore, row[i].attrs)
     if current_attr_id and attr_id ~= current_attr_id then
       -- close current attribute bracket, add it before any whitespace
@@ -581,7 +609,7 @@ function Screen:_row_repr(row, attr_ids, attr_ignore)
       table.insert(rv, '{' .. attr_id .. ':')
       current_attr_id = attr_id
     end
-    if not self._busy and self._rows[self._cursor.row] == row and self._cursor.col == i then
+    if not self._busy and cursor and self._cursor.col == i then
       table.insert(rv, '^')
     end
     table.insert(rv, row[i].text)
@@ -592,16 +620,6 @@ function Screen:_row_repr(row, attr_ids, attr_ignore)
   -- return the line representation, but remove empty attribute brackets and
   -- trailing whitespace
   return table.concat(rv, '')--:gsub('%s+$', '')
-end
-
-
-function Screen:_current_screen()
-  -- get a string that represents the current screen state(debugging helper)
-  local rv = {}
-  for i = 1, self._height do
-    table.insert(rv, "'"..self:_row_repr(self._rows[i]).."'")
-  end
-  return table.concat(rv, '\n')
 end
 
 -- Generates tests. Call it where Screen:expect() would be. Waits briefly, then
@@ -631,6 +649,38 @@ function Screen:redraw_debug(attrs, ignore, timeout)
   run(nil, notification_cb, nil, timeout)
 end
 
+function Screen:find_attrs(attrs)
+  for i,grid in ipairs(self._grids) do
+    for i = 1, grid.height do
+      local row = grid.rows[i]
+      for j = 1, grid.width do
+        local attr = row[j].attrs
+        if self:_attr_index(attrs, attr) == nil and self:_attr_index(ignore, attr) == nil then
+          if not self:_equal_attrs(attr, {}) then
+            table.insert(attrs, attr)
+          end
+        end
+      end
+    end
+  end
+end
+
+function Screen:render(headers,attrs,ignore,preview)
+  headers = headers and self._float
+  local rv = {}
+  for igrid,grid in ipairs(self._grids) do
+    if headers then
+      table.insert(rv, "## grid "..igrid)
+    end
+    for i = 1, grid.height do
+      cursor = self._cursor.grid == igrid and self._cursor.row == i
+      prefix = (headers or preview) and "  " or ""
+      table.insert(rv, prefix..self:_row_repr(grid.rows[i],attrs, ignore, cursor).."|")
+    end
+  end
+  return rv
+end
+
 function Screen:print_snapshot(attrs, ignore)
   if ignore == nil then
     ignore = self._default_attr_ignore
@@ -644,24 +694,11 @@ function Screen:print_snapshot(attrs, ignore)
     end
 
     if ignore ~= true then
-      for i = 1, self._height do
-        local row = self._rows[i]
-        for j = 1, self._width do
-          local attr = row[j].attrs
-          if self:_attr_index(attrs, attr) == nil and self:_attr_index(ignore, attr) == nil then
-            if not self:_equal_attrs(attr, {}) then
-              table.insert(attrs, attr)
-            end
-          end
-        end
-      end
+      self:find_attrs(attrs)
     end
   end
 
-  local rv = {}
-  for i = 1, self._height do
-    table.insert(rv, "  "..self:_row_repr(self._rows[i],attrs, ignore).."|")
-  end
+  rows = self:render(true,attrs,ignore,true)
   local attrstrs = {}
   local alldefault = true
   for i, a in ipairs(attrs) do
@@ -672,8 +709,9 @@ function Screen:print_snapshot(attrs, ignore)
     table.insert(attrstrs, "["..tostring(i).."] = "..dict)
   end
   local attrstr = "{"..table.concat(attrstrs, ", ").."}"
+
   print( "\nscreen:expect([[")
-  print( table.concat(rv, '\n'))
+  print( table.concat(rows, '\n'))
   if alldefault then
     print( "]])\n")
   else

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -309,7 +309,19 @@ function Screen:wait(check, timeout)
 
     return true
   end
-  run_session(self._session, nil, notification_cb, nil, timeout or self.timeout)
+  local function request_cb(method, args)
+    local handler_name = '_handle_'..method
+    local handler = self[handler_name]
+    if handler ~= nil then
+      handler(self, unpack(args))
+    else
+      assert(self._on_request,
+        "Add Screen:"..handler_name.." or call Screen:set_on_request_handler")
+      self._on_request(method, args)
+    end
+    return true
+  end
+  run_session(self._session, request_cb, notification_cb, nil, timeout or self.timeout)
   if not checked then
     err = check()
   end
@@ -360,6 +372,10 @@ end
 
 function Screen:set_on_event_handler(callback)
   self._on_event = callback
+end
+
+function Screen:set_on_request_handler(callback)
+  self._on_request = callback
 end
 
 function Screen:_handle_resize(width, height)

--- a/test/functional/ui/screen_multigrid_spec.lua
+++ b/test/functional/ui/screen_multigrid_spec.lua
@@ -1,0 +1,69 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
+local feed, command = helpers.feed, helpers.command
+
+describe('multigrid screen', function()
+  local screen
+  local nvim_argv = {helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+                     '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
+                     '--embed'}
+
+  before_each(function()
+    local screen_nvim = spawn(nvim_argv)
+    set_session(screen_nvim)
+    screen = Screen.new()
+    screen:attach({ext_multigrid=true})
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {foreground = Screen.colors.Magenta},
+      [3] = {foreground = Screen.colors.Brown, bold = true},
+      [4] = {foreground = Screen.colors.SlateBlue},
+      [5] = {bold = true, foreground = Screen.colors.SlateBlue},
+      [6] = {foreground = Screen.colors.Cyan4},
+      [7] = {bold = true},
+      [8] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
+      [9] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [10] = {foreground = Screen.colors.Red},
+      [11] = {bold = true, reverse = true}
+    })
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('default initial screen', function()
+    screen:expect([[
+    ## grid 1
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+                                                           |
+      {11:[No Name]                                            }|
+                                                           |
+    ## grid 2
+      ^                                                     |
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+    ]])
+  end)
+
+end)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -45,11 +45,11 @@ local check_logs_useless_lines = {
   ['See README_MISSING_SYSCALL_OR_IOCTL for guidance']=3,
 }
 
-local function eq(expected, actual)
-  return assert.are.same(expected, actual)
+local function eq(expected, actual, context)
+  return assert.are.same(expected, actual, context)
 end
-local function neq(expected, actual)
-  return assert.are_not.same(expected, actual)
+local function neq(expected, actual, context)
+  return assert.are_not.same(expected, actual, context)
 end
 local function ok(res)
   return assert.is_true(res)


### PR DESCRIPTION
_The first 4 commits will become obsolete when merging with `grid-split`; remove them then._

Desired tests:
- [x] default screen
- [x] `:split`, `:vertical split`
- [x] `CTRL_W r`
- [x] `CTRL_W x`
- [x] `CTRL_W J`
- [x] `CTRL_W T`
- [x] `CTRL_W =`
- [x] `:resize`, `:vertical resize`
- [x] `CTRL_W +`
- [x] `CTRL_W j`
- [x] `CTRL_W c`